### PR TITLE
feat: polish homepage and add studio watermark

### DIFF
--- a/next-pwa.d.ts
+++ b/next-pwa.d.ts
@@ -1,4 +1,4 @@
-declare module 'next-pwa' {
-  const withPWA: any;
+declare module "next-pwa" {
+  const withPWA: (options?: unknown) => unknown;
   export default withPWA;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,6 +68,12 @@ input[type="search"]:focus{
 .badge:hover{background:#e5e7eb}
 .badge[data-active="true"]{background:var(--chip-active);color:var(--chip-active-text)}
 
+/* 首頁浮水印 */
+.watermark{
+  position:fixed;bottom:12px;right:16px;
+  font-size:12px;color:var(--muted);opacity:.8;
+}
+
 /* 卡片與圖片 */
 .grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fill,minmax(220px,1fr))}
 .card{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,27 +8,20 @@ export default function HomePage() {
   const tags = getTopTags(12);
 
   return (
-    <main style={{ padding: 16 }}>
+    <main className="container" style={{ minHeight: "100vh" }}>
       <h1>快速搜尋</h1>
-      <p>目前共 {total} 個案例。輸入關鍵字（中/英），或點選標籤。</p>
+      <p className="muted">目前共 {total} 個案例。輸入關鍵字（中/英），或點選標籤。</p>
 
-      <form action="/cases" method="get" style={{ display: "flex", gap: 8, margin: "12px 0 16px" }}>
-        <input
-          type="search"
-          name="q"
-          placeholder="例：手辦、Anime、遮罩、光影…"
-          style={{ flex: 1, padding: "10px 12px" }}
-        />
-        <button type="submit">搜尋</button>
+      <form action="/cases" method="get" className="row" style={{ margin: "12px 0 16px" }}>
+        <input type="search" name="q" placeholder="例：手辦、Anime、遮罩、光影…" />
+        <button type="submit" className="btn">
+          搜尋
+        </button>
       </form>
 
       <div style={{ marginTop: 8 }}>
         {tags.map((t) => (
-          <Link
-            key={t}
-            href={`/cases?tag=${encodeURIComponent(t)}`}
-            style={{ display: "inline-block", padding: "4px 10px", marginRight: 8, marginBottom: 8, background: "#eee", borderRadius: 999 }}
-          >
+          <Link key={t} href={`/cases?tag=${encodeURIComponent(t)}`} className="badge">
             {t}
           </Link>
         ))}
@@ -37,6 +30,8 @@ export default function HomePage() {
       <p style={{ marginTop: 20 }}>
         <Link href="/cases">→ 前往所有案例列表</Link>
       </p>
+
+      <div className="watermark">Li&apos;s Meet AI Studio</div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- style homepage using shared components and badge/button styles
- add fixed "Li's Meet AI Studio" watermark in bottom-right corner
- replace `any` typing in `next-pwa.d.ts` to satisfy lint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf730a11dc832e98986bbde7d2f8d1